### PR TITLE
Fix outdated toAscii() usage

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -219,5 +219,5 @@ void MainWindow::on_action_Options_triggered()
 void MainWindow::on_editbtn_clicked()
 {
     QString cmdline=settings->value("option/editcmd","binhexedit -r").toString() +" " + ui->filename->text();
-    system(cmdline.toAscii());
+    system(cmdline.toLatin1());
 }


### PR DESCRIPTION
A small change to allow it to compile using recent versions of qt5.
(ref http://doc.qt.io/qt-5/qstring-obsolete.html#toAscii )
